### PR TITLE
Fix failures to configure RAID with newish dracclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Requirements
 ------------
 
 The role provides a module, `drac`, that is dependent upon the
-`python-dracclient` module. This must be installed in order for this module
-to function correctly.
+`python-dracclient` package version 2.0.0 or greater. This must be installed in
+order for this module to function correctly.
 
 Role Variables
 --------------

--- a/library/drac.py
+++ b/library/drac.py
@@ -1280,7 +1280,7 @@ def validate_args(module):
     if invalid_vdisks:
         module.fail_json(msg="RAID configuration must be a list of dicts with "
                          "the following items: 'name', 'raid_level', "
-                         "'span_length', 'span_depth', 'pdisks'. The 'pdisks'"
+                         "'span_length', 'span_depth', 'pdisks'. The 'pdisks' "
                          "item should be a list of IDs of physical disks. The "
                          "following items were invalid: %s" % invalid_vdisks)
 

--- a/library/drac.py
+++ b/library/drac.py
@@ -43,7 +43,7 @@ description:
     configuration, this module may take a long time to execute.
 author: Mark Goddard (@markgoddard) & Stig Telfer (@oneswig)
 requirements:
-  - python-dracclient python module
+  - python-dracclient >= 2.0.0
 options:
   address:
     description: Address to use when communicating with the DRAC

--- a/library/drac.py
+++ b/library/drac.py
@@ -552,7 +552,7 @@ class RAIDConfig(DRACConfig):
         for goal_vdisk in goal_vdisks.values():
             for pdisk_id in goal_vdisk['pdisks']:
                 pdisk = self.pdisks[pdisk_id]
-                if pdisk.raid_state == 'non-RAID':
+                if pdisk.raid_status == 'non-RAID':
                     self.converting.append(pdisk_id)
 
         # Determine which of the requested virtual disks need to be deleted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,8 +2,8 @@
 # We use local_action to execute the module on the local host,
 # interacting with the DRACs via their APIs.
 - name: Ensure that DRAC configuration is applied
-  local_action:
-    module: drac
+  delegate_to: localhost
+  drac:
     address: "{{ drac_address }}"
     username: "{{ drac_username }}"
     password: "{{ drac_password }}"

--- a/tests/test_drac.py
+++ b/tests/test_drac.py
@@ -355,11 +355,11 @@ class TestDRACBIOS(BaseTestCase):
 
 
 class FakePDisk(object):
-    def __init__(self, id, controller, size_mb, raid_state='ready'):
+    def __init__(self, id, controller, size_mb, raid_status='ready'):
         self.id = id
         self.controller = controller
         self.size_mb = size_mb
-        self.raid_state = raid_state
+        self.raid_status = raid_status
 
 
 class FakeController(object):


### PR DESCRIPTION
The failure was due to the deprecated `raid_state` attribute being removed.