### PR TITLE
Calculate RAID size_mb parameter correctly

### DIFF
--- a/tests/test_drac.py
+++ b/tests/test_drac.py
@@ -1015,6 +1015,93 @@ class TestDRACRAID(BaseTestCase):
              'span_length': 2, 'pending_operations': None,
              'physical_disks': ['pdisk3', 'pdisk4']})
 
+    def test_compute_size_mb(self):
+        goal_vdisk0 = {
+            'name': 'vdisk0',
+            'raid_level': 0,
+            'span_length': 1,
+            'span_depth': 2,
+            'pdisks': [
+                'pdisk1', 'pdisk2',
+            ],
+        }
+        self.assertEqual(
+            42 * 2, FakeRAIDConfig._compute_size_mb(goal_vdisk0, 42))
+
+        goal_vdisk1 = {
+            'name': 'vdisk1',
+            'raid_level': 1,
+            'span_length': 2,
+            'span_depth': 1,
+            'pdisks': [
+                'pdisk1', 'pdisk2',
+            ],
+        }
+        self.assertEqual(
+            42, FakeRAIDConfig._compute_size_mb(goal_vdisk1, 42))
+
+        goal_vdisk5 = {
+            'name': 'vdisk5',
+            'raid_level': 5,
+            'span_length': 3,
+            'span_depth': 1,
+            'pdisks': [
+                'pdisk1', 'pdisk2', 'pdisk3',
+            ],
+        }
+        self.assertEqual(
+            42 * 2, FakeRAIDConfig._compute_size_mb(goal_vdisk5, 42))
+
+        goal_vdisk6 = {
+            'name': 'vdisk6',
+            'raid_level': 6,
+            'span_length': 4,
+            'span_depth': 1,
+            'pdisks': [
+                'pdisk1', 'pdisk2', 'pdisk3', 'pdisk4',
+            ],
+        }
+        self.assertEqual(
+            42 * 2, FakeRAIDConfig._compute_size_mb(goal_vdisk6, 42))
+
+        goal_vdisk10 = {
+            'name': 'vdisk10',
+            'raid_level': '1+0',
+            'span_length': 2,
+            'span_depth': 3,
+            'pdisks': [
+                'pdisk1', 'pdisk2', 'pdisk3', 'pdisk4', 'pdisk5', 'pdisk6',
+            ],
+        }
+        self.assertEqual(
+            42 * 3, FakeRAIDConfig._compute_size_mb(goal_vdisk10, 42))
+
+        goal_vdisk50 = {
+            'name': 'vdisk50',
+            'raid_level': '5+0',
+            'span_length': 3,
+            'span_depth': 3,
+            'pdisks': [
+                'pdisk1', 'pdisk2', 'pdisk3', 'pdisk4', 'pdisk5', 'pdisk6',
+                'pdisk7', 'pdisk8', 'pdisk9',
+            ],
+        }
+        self.assertEqual(
+            42 * 2 * 3, FakeRAIDConfig._compute_size_mb(goal_vdisk50, 42))
+
+        goal_vdisk60 = {
+            'name': 'vdisk60',
+            'raid_level': '6+0',
+            'span_length': 4,
+            'span_depth': 2,
+            'pdisks': [
+                'pdisk1', 'pdisk2', 'pdisk3', 'pdisk4', 'pdisk5', 'pdisk6',
+                'pdisk7', 'pdisk8',
+            ],
+        }
+        self.assertEqual(
+            42 * 2 * 2, FakeRAIDConfig._compute_size_mb(goal_vdisk60, 42))
+
 
 class FakeBIOSConfig(drac.BIOSConfig):
     def __init__(self, state, changing_settings):


### PR DESCRIPTION
The current calculation of the size_mb parameter is incorrect for RAID
levels using parity disks, such as RAID 5 or RAID 6. It results in a
virtual disk that is much smaller than expected. For example, a RAID 5
would only be as big as the smallest disk.

This commit uses the formula described in issue #4 [1], but adapted to
support all RAID levels listed in python-dracclient [2].

[1] https://github.com/stackhpc/drac/issues/4#issuecomment-409946211
[2] https://opendev.org/openstack/python-dracclient/src/tag/3.1.1/dracclient/resources/raid.py#L25-L34

Co-authored-by: Mark Goddard <mark@stackhpc.com>