### PR TITLE
Fix evaluation of check_mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,4 +13,4 @@
     timeout: "{{ drac_timeout }}"
     interval: "{{ drac_interval }}"
   register: drac_result
-  check_mode: "{{ drac_check_mode | default(ansible_check_mode) }}"
+  check_mode: "{{ drac_check_mode | default(ansible_check_mode, true) | bool }}"


### PR DESCRIPTION
With drac_check_mode defaulting to null, the expression used for
check_mode was evaluated as an empty string, which failed because
check_mode expects a valid boolean.

Pass true as second argument to the default filter to force use of the
default value. Also add bool filter while here.

Closes #8.